### PR TITLE
Switch data/payload to align with naming in listener and core, pass through github_guid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 rvm:
   - 1.9.3


### PR DESCRIPTION
The naming of data vs payload confused the heck out of me because it's the exact opposite of how things are named in listener and core, so I flipped it around.

`github_guid` is passed by listener, and used in core (`Request::Service::Receive`), but not passed through. With this change it will now be passed.

How to deploy: bump travis-sidekiqs in gatekeeper, deploy gatekeeper to production
