### PR TITLE
Making the gemspec valid in the eyes of gem/bundler

### DIFF
--- a/travis-sidekiqs.gemspec
+++ b/travis-sidekiqs.gemspec
@@ -3,20 +3,18 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
-  gem.name          = "travis-sidekiqs"
-  gem.version       = "0.0.1"
-  gem.authors       = ["Mathias Meyer"]
-  gem.email         = ["meyer@paperplanes.de"]
-  gem.description   = %q{Async, baby!}
+  gem.name          = 'travis-sidekiqs'
+  gem.version       = '0.0.1'
+  gem.authors       = ['Mathias Meyer']
+  gem.email         = ['meyer@paperplanes.de']
   gem.summary       = %q{Async, baby!}
-  gem.homepage      = ""
+  gem.description   = gem.summary + '  No, really!'
+  gem.homepage      = 'https://github.com/travis-ci/travis-sidekiqs'
+  gem.license       = 'MIT'
 
-  gem.files         = `git ls-files`.split($/)
+  gem.files         = `git ls-files -z`.split("\0")
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.require_paths = ["lib"]
+  gem.require_paths = %w{lib}
   gem.add_dependency 'sidekiq', '~> 2.17'
-  # TODO this seems to force every app that uses travis-core to also use
-  # raven for error reporting, is that what want?
-  # gem.add_dependency 'sentry-raven'
 end


### PR DESCRIPTION
In this piece, I replace multiple double quotes with single quotes, add a license field, make the description and summary different, and build the file list with null-separated entries rather than newlines.  It is an important work, as the gemspec becomes pleasing to both gem and bundler, thus reducing the likelihood of unfortunate events while deploying to heroku.
